### PR TITLE
Spinner type changed to any due to typescript incompatibility

### DIFF
--- a/src/commands/tcam/create-project.ts
+++ b/src/commands/tcam/create-project.ts
@@ -11,7 +11,7 @@ export default class TcamCreateProject extends TCBaseCommand {
   static description = 'Create a project';
   static examples: string[] | undefined = [`tibco tcam:create-project --name "Cli Project"`,
     `tibco tcam:create-project -n "Cli Project"`];
-  spinner!:  Awaited<ReturnType<typeof ux.spinner>>;
+  spinner: any;
   static flags: flags.Input<any> & typeof TCBaseCommand.flags = {
     ...TCBaseCommand.flags,
     help: flags.help({ char: 'h' }),

--- a/src/commands/tcam/export-apis.ts
+++ b/src/commands/tcam/export-apis.ts
@@ -18,7 +18,7 @@ export default class TcamExportApis extends TCBaseCommand {
   static examples: string[] | undefined = [`tibco tcam:export-apis --projectname "Cli Project"`,
     `tibco tcam:export-apis --projectname "Cli Project" --apinames 'InvalidApi,CliOpenApi" --yaml`,
     `tibco tcam:export-apis -p "Cli Project" -a "InvalidApi,CliOpenApi" -y`];
-  spinner!:  Awaited<ReturnType<typeof ux.spinner>>;
+  spinner: any;
   static flags: flags.Input<any> & typeof TCBaseCommand.flags = {
     ...TCBaseCommand.flags,
     help: flags.help({ char: 'h' }),

--- a/src/commands/tcam/generate-mock.ts
+++ b/src/commands/tcam/generate-mock.ts
@@ -23,7 +23,7 @@ export default class TcamGenMock extends TCBaseCommand {
       `tibco tcam:generate-mock -f "C:/Users/myuser/Desktop/Upload/ImportApi.json" -d -s`];
   // spinner: typeof ux.spinner;
   tcReq: TCRequest = this.getTCRequest();
-  spinner!:  Awaited<ReturnType<typeof ux.spinner>>;
+  spinner: any;
   tmpStorage = '';
   static flags: flags.Input<any> & typeof TCBaseCommand.flags = {
     ...TCBaseCommand.flags,

--- a/src/commands/tcam/import-apis.ts
+++ b/src/commands/tcam/import-apis.ts
@@ -19,7 +19,7 @@ export default class TcamImportApis extends TCBaseCommand {
     "tibco tcam:import-apis --from 'C:/Users/myuser/Desktop/Upload/ImportApi.json' --projectname 'TestProject'",
     "tibco tcam:import-apis -f 'C:/Users/myuser/Desktop/Upload/ImportProject' -p 'TestProject'"
   ];
-  spinner!: Awaited<ReturnType<typeof ux.spinner>>;
+  spinner: any;
   static flags: flags.Input<any> & typeof TCBaseCommand.flags = {
     ...TCBaseCommand.flags,
     help: flags.help({ char: 'h' }),

--- a/src/commands/tcam/list-apis.ts
+++ b/src/commands/tcam/list-apis.ts
@@ -14,7 +14,7 @@ export default class TcamListApis extends TCBaseCommand {
     `tibco tcam:list-apis --apitypes "openapi"`, `tibco tcam:list-apis -p "AuthProject" -t "openapi"`,
     `tibco tcam:list-apis --apinames "CliAsyncApi,CliOpenApi"`
   ];
-  spinner!: Awaited<ReturnType<typeof ux.spinner>>;
+  spinner: any;
   static flags: flags.Input<any> & typeof TCBaseCommand.flags = {
     ...TCBaseCommand.flags,
     help: flags.help({ char: 'h' }),

--- a/src/commands/tcam/list-projects.ts
+++ b/src/commands/tcam/list-projects.ts
@@ -13,7 +13,7 @@ export default class TcamListProjects extends TCBaseCommand {
   `tibco tcam:list-projects --projectnames "Cli Project, UI Project"`,
   `tibco tcam:list-projects -p "Cli Project, UI Project"`
    ];
-  spinner!: Awaited<ReturnType<typeof ux.spinner>>;
+  spinner: any;
   static flags: flags.Input<any> & typeof TCBaseCommand.flags = {
     ...TCBaseCommand.flags,
     help: flags.help({char: 'h'}),

--- a/src/commands/tcam/validate-apis.ts
+++ b/src/commands/tcam/validate-apis.ts
@@ -19,7 +19,7 @@ export default class TcamValidateApis extends TCBaseCommand {
         `tibco tcam:validate-apis --from "C:/Users/myuser/Desktop/Upload/ImportProject" --apinames "bankapi,yamlapi"`,
         `tibco tcam:validate-apis -f "C:/Users/myuser/Desktop/Upload/ImportProject" -a "bankapi,yamlapi"`
     ];
-    spinner!: Awaited<ReturnType<typeof ux.spinner>>;
+    spinner: any;
     static flags: flags.Input<any> & typeof TCBaseCommand.flags = {
         ...TCBaseCommand.flags,
         help: flags.help({ char: 'h' }),


### PR DESCRIPTION
## Description

Change data type of spinner variable to any.

## Motivation and Context

Type for spinner variable is `Awaited<ReturnType<typeof ux.spinner>>`. But Awaited type is part of typescript version 4.5 and above , but our code uses typescript 3.9. So the compilation is failing due to this.


## How has this been tested?

Manually

## Types of changes

- [ ] Typescript bug fix (non-breaking change which fixes an issue)